### PR TITLE
fix proptype oneOfType check

### DIFF
--- a/src/Iframe.js
+++ b/src/Iframe.js
@@ -89,7 +89,7 @@ Iframe.propTypes = {
     }),
   }),
   options: PropTypes.shape({
-    url: PropTypes.oneOf([PropTypes.string, PropTypes.func]),
+    url: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   }),
 }
 


### PR DESCRIPTION
PropTypes.oneOf is for checking specifc values as enum, while oneOfType checks the type.

Solves warning:

> Failed prop type: Invalid prop `options.url` of value `doc => (0, _resolvePreviewUrl.default)(doc)` supplied to `Iframe`, expected one of [null,null].