### PR TITLE
Revision delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ S.view
     // Optional: Add a reload button, or reload on new document revisions
     reload: {
       button: true, // default `undefined`
-      revision: true, // default `undefined`
-      revisionDelay: 500, // optional - add a delay (in ms) before the automatic reload on document revisions
+      revision: true, // boolean | number. default `undefined`. If a number is provided, add a delay (in ms) before the automatic reload on document revision
     },
   })
   .title("Preview");

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ S.view
     reload: {
       button: true, // default `undefined`
       revision: true, // default `undefined`
+      revisionDelay: 500, // add a delay (in ms) before the automatic reload on document revisions
     },
   })
   .title("Preview");

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ S.view
     reload: {
       button: true, // default `undefined`
       revision: true, // default `undefined`
-      revisionDelay: 500, // add a delay (in ms) before the automatic reload on document revisions
+      revisionDelay: 500, // optional - add a delay (in ms) before the automatic reload on document revisions
     },
   })
   .title("Preview");

--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -15,6 +15,7 @@ export type IframeOptions = {
   defaultSize?: 'desktop' | 'mobile'
   reload: {
     revision: boolean
+    revisionDelay?: number
     button: boolean
   }
 }
@@ -55,7 +56,9 @@ function Iframe(props: IframeProps) {
   // Reload on new revisions
   useEffect(() => {
     if (reload?.revision) {
-      handleReload()
+      setTimeout(() => {
+        handleReload()
+      }, reload?.revisionDelay)
     }
   }, [displayed._rev, reload?.revision])
 

--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -14,8 +14,7 @@ export type IframeOptions = {
   url: string | ((document: SanityDocumentLike) => unknown)
   defaultSize?: 'desktop' | 'mobile'
   reload: {
-    revision: boolean
-    revisionDelay?: number
+    revision: boolean | number
     button: boolean
   }
 }
@@ -55,10 +54,10 @@ function Iframe(props: IframeProps) {
 
   // Reload on new revisions
   useEffect(() => {
-    if (reload?.revision) {
+    if (reload?.revision || reload.revision == 0) {
       setTimeout(() => {
         handleReload()
-      }, reload?.revisionDelay)
+      }, Number(reload?.revision))
     }
   }, [displayed._rev, reload?.revision])
 


### PR DESCRIPTION
I've found using Shopify's Hydrogen (with React 18 server components) that caching (or some other mysterious goings on) is causing previews to not be immediately up to date. This option allows for a delay between revisions and the automatic reload to compensate for this.