### PR TITLE
Add `iframe` attributes to configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ S.view
       button: true, // default `undefined`
       revision: true, // boolean | number. default `undefined`. If a number is provided, add a delay (in ms) before the automatic reload on document revision
     },
+    // Optional: Pass attributes to the underlying `iframe` element:
+    // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+    attributes: {
+      allow: 'fullscreen' // string, optional
+      referrerPolicy: 'strict-origin-when-cross-origin' // string, optional
+      sandbox: 'allow-same-origin' // string, optional
+    }
   })
   .title("Preview");
 ```

--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -17,6 +17,11 @@ export type IframeOptions = {
     revision: boolean | number
     button: boolean
   }
+  attributes?: Partial<{
+    allow: string
+    referrerPolicy: string
+    sandbox: string
+  }>
 }
 
 export type IframeProps = {
@@ -28,7 +33,7 @@ export type IframeProps = {
 
 function Iframe(props: IframeProps) {
   const {document: sanityDocument, options} = props
-  const {url, defaultSize = `desktop`, reload} = options
+  const {url, defaultSize = `desktop`, reload, attributes} = options
   const [displayUrl, setDisplayUrl] = useState(typeof url === 'string' ? url : ``)
   const [iframeSize, setIframeSize] = useState(defaultSize)
   const input = useRef()
@@ -153,6 +158,7 @@ function Iframe(props: IframeProps) {
               style={sizes[iframeSize]}
               frameBorder="0"
               src={displayUrl}
+              {...attributes}
             />
           </Flex>
         </Card>

--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -33,7 +33,7 @@ export type IframeProps = {
 
 function Iframe(props: IframeProps) {
   const {document: sanityDocument, options} = props
-  const {url, defaultSize = `desktop`, reload, attributes} = options
+  const {url, defaultSize = `desktop`, reload, attributes = {}} = options
   const [displayUrl, setDisplayUrl] = useState(typeof url === 'string' ? url : ``)
   const [iframeSize, setIframeSize] = useState(defaultSize)
   const input = useRef()


### PR DESCRIPTION
Added the following attributes to pass through to the `iframe`:

- [referrerpolicy](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-referrerpolicy)
- [sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox)
- [allow](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow)